### PR TITLE
Resolve: SSR logs페이지 500 error -> CSR rollback (#17)

### DIFF
--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/Input";
 import { useState } from "react";
 import { useRouter } from "next/router";
 import axios from "../lib/axios";
-import { setCookie } from "cookies-next";
+// import { setCookie } from "cookies-next";
 
 export default function Login() {
   const router = useRouter();
@@ -37,8 +37,11 @@ export default function Login() {
       if (response.status === 200) {
         localStorage.setItem("userName", response.data.data.name);
         localStorage.setItem("userEmail", response.data.data.email);
-        setCookie("userName", response.data.data.name);
-        setCookie("userEmail", response.data.data.email);
+        /**
+         * SSR 환경을 위한 쿠기 설정
+         */
+        // setCookie("userName", response.data.data.name);
+        // setCookie("userEmail", response.data.data.email);
         router.push("/");
       }
     } catch (error) {

--- a/pages/logs.jsx
+++ b/pages/logs.jsx
@@ -6,93 +6,101 @@ import {
   Card,
 } from "@/components/Card";
 import { StarIcon } from "@/components/constants/Icons";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import axios from "../lib/axios";
 import Modal from "@/components/Modal";
 import RenderLogActionsContent from "@/components/RenderLogActionsContent";
 import RenderLogMetaDataContent from "@/components/RenderLogMetaDataContent";
 import RenderLogPreviewContent from "@/components/RenderLogPreviewContent";
-// import LogLeftBarSkeleton from "@/components/LogLeftBarSkeletonUi";
+import LogLeftBarSkeleton from "@/components/LogLeftBarSkeletonUi";
 
-export async function getServerSideProps(context) {
-  const userEmail = context.req.cookies.userEmail;
-  console.log("userEmail", userEmail);
-  let extractions = [];
+/**
+ * 서버사이드 렌더링을 위한 getServerSideProps 함수
+ * @param {*} context
+ * @returns props
+ */
+// export async function getServerSideProps(context) {
+//   const userEmail = context.req.cookies.userEmail;
+//   console.log("userEmail", userEmail);
+//   let extractions = [];
 
-  // Redirect to login page if user is not logged in
-  if (userEmail === undefined) {
-    return {
-      redirect: {
-        destination: "/login",
-        permanent: false,
-      },
-    };
-  }
+//   // Redirect to login page if user is not logged in
+//   if (userEmail === undefined) {
+//     return {
+//       redirect: {
+//         destination: "/login",
+//         permanent: false,
+//       },
+//     };
+//   }
 
-  // Fetch Metadata Logs
-  try {
-    const response = await axios.get("/metadata/logs", {
-      params: { email: userEmail },
-    });
-    extractions = response.data.data.logs;
-  } catch (e) {
-    // 500 error custom page
-    return {
-      notFound: true,
-    };
-  }
+//   // Fetch Metadata Logs
+//   try {
+//     const response = await axios.get("/metadata/logs", {
+//       params: { email: userEmail },
+//     });
+//     extractions = response.data.data.logs;
+//   } catch (e) {
+//     console.error(e);
+//     // 500 error custom page
+//     return {
+//       notFound: true,
+//     };
+//   }
 
-  return {
-    props: {
-      userEmail,
-      extractions: extractions,
-    },
-  };
-}
+//   return {
+//     props: {
+//       userEmail,
+//       extractions: extractions,
+//     },
+//   };
+// }
 
-export default function Logs({ userEmail, extractions }) {
-  // const [userEmail, setUserEmail] = useState("");
-  // const [extractions, setExtractions] = useState([]);
+export default function Logs() {
+  const [userEmail, setUserEmail] = useState("");
+  const [extractions, setExtractions] = useState([]);
   const [selectedExtraction, setSelectedExtraction] = useState(null);
-  // const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [evalueateModal, setEvalueateModal] = useState(false);
   const [rating, setRating] = useState(0);
   const [feedback, setFeedback] = useState("");
   const [showAll, setShowAll] = useState(false);
 
-  /**  서버 사이드 렌더링 전, CSR, skeleton UI 구현 코드 입니다. */
+  /**
+   * CSR, Skeleton UI
+   */
 
   // Fetch User Email from LocalStorage
-  // useEffect(() => {
-  //   if (typeof window !== "undefined") {
-  //     const storedUserName = localStorage.getItem("userEmail");
-  //     if (storedUserName) {
-  //       setUserEmail(storedUserName);
-  //     }
-  //   }
-  // }, []);
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const storedUserName = localStorage.getItem("userEmail");
+      if (storedUserName) {
+        setUserEmail(storedUserName);
+      }
+    }
+  }, []);
 
   // Fetch Metadata Logs
-  // useEffect(() => {
-  //   if (userEmail) {
-  //     const fetchMetadata = async () => {
-  //       try {
-  //         setIsLoading(true);
-  //         const response = await axios.get("/metadata/logs", {
-  //           params: { email: userEmail },
-  //         });
-  //         console.log(response);
-  //         setExtractions(response.data.data.logs);
-  //       } catch (e) {
-  //         alert("Failed to fetch metadata.");
-  //       } finally {
-  //         setIsLoading(false);
-  //       }
-  //     };
+  useEffect(() => {
+    if (userEmail) {
+      const fetchMetadata = async () => {
+        try {
+          setIsLoading(true);
+          const response = await axios.get("/metadata/logs", {
+            params: { email: userEmail },
+          });
 
-  //     fetchMetadata();
-  //   }
-  // }, [userEmail]);
+          setExtractions(response.data.data.logs);
+        } catch (e) {
+          alert("Failed to fetch metadata.");
+        } finally {
+          setIsLoading(false);
+        }
+      };
+
+      fetchMetadata();
+    }
+  }, [userEmail]);
 
   // LeftBar Click Handler
   const handleExtractionClick = (extraction) => {
@@ -212,15 +220,13 @@ export default function Logs({ userEmail, extractions }) {
       {/* LeftBar */}
       <div className="bg-white p-4 flex flex-col items-start justify-between border border-gray-200 md:w-1/5 lg:w-1/6 h-full overflow-y-auto">
         <nav className="space-y-2 w-full">
-          {/* {isLoading ? (
+          {isLoading ? (
             <>
               <LogLeftBarSkeleton />
               <LogLeftBarSkeleton />
               <LogLeftBarSkeleton />
             </>
-          ) : */}
-
-          {extractions.length ? (
+          ) : extractions.length ? (
             extractions.map((extraction, index) => (
               <div
                 key={index}


### PR DESCRIPTION
**resolved(#17)**

/metadata/logs/{log번호}로 get요청을 통해 받아오는 것이 아니라, /metadata/logs로 모든 데이터를 받아오다 보니 굳이 SSR을 쓰면 시간이 많이 걸리고, 파일 양이 커질 것 같다는 우려가 있었는데 맞았다. 

Vercel logs를 통해 로그를 통해 확인할 수 있었고, Vercel에서 무료로 제공하는 정적파일 양을 넘은 것이라 생각한다. 

SEO가 필요한 서비스도 아니고 CSR로직에 데이터를 받아오기까지 skeleton UI도 있으니, CSR로 rollback 결정. 

![스크린샷 2024-06-20 오후 9 03 00](https://github.com/sw24-11/llmeta-fe/assets/113183107/64792b0d-e5b6-4586-9bbd-d05ec81f3d62)
